### PR TITLE
obj and path already declared; uninitialized vars at bottom

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,17 +7,18 @@
  */
 function hasify(obj, str) {
 
-    var obj = obj === undefined ? {} : obj;
+    obj = obj === undefined ? {} : obj;
 
     if (str) {
         return has.call(obj, str);
     }
 
     function has(path) {
-        var path = path.split('.'),
-            node,
-            working = this,
-            isValid = true;
+        var working = this,
+            isValid = true,
+            node;
+
+        path = path.split('.');
 
         do {
             node = path.shift();


### PR DESCRIPTION
obj and path are already available as variables from the parameters, so they don't need to be declared. I also moved the uninitialized node var to the bottom of the var declarations in has().
